### PR TITLE
fix wrong GOBIN, support custom run method

### DIFF
--- a/realize/cli.go
+++ b/realize/cli.go
@@ -65,7 +65,8 @@ func init() {
 	if build.Default.GOPATH == "" {
 		log.Fatal("$GOPATH isn't set properly")
 	}
-	if err := os.Setenv("GOBIN", filepath.Join(build.Default.GOPATH, "bin")); err != nil {
+	path := filepath.SplitList(build.Default.GOPATH)
+	if err := os.Setenv("GOBIN", filepath.Join(path[len(path)-1], "bin")); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/realize/projects.go
+++ b/realize/projects.go
@@ -582,6 +582,9 @@ func (p *Project) run(path string, stream chan Response, stop <-chan bool) (err 
 		name = filepath.Base(dirPath)
 	}
 	path = filepath.Join(dirPath, name)
+	if p.Tools.Run.Method != "" {
+        path = p.Tools.Run.Method
+	}
 	if _, err := os.Stat(path); err == nil {
 		build = exec.Command(path, args...)
 	} else if _, err := os.Stat(path + RExtWin); err == nil {


### PR DESCRIPTION
- Fix wrong GOBIN when GOPATH includes multi directories.
- Support custom run method: Allow to config path to binary to run when using custom build method or pass custom output arg to build command, ex:
   ```yml
   commands:
      build:
         status: true
         args:
         - -o /path/to/output/out
      run:
         status: true
         method: /path/to/output/out
   ```