### PR TITLE
Replace Tool.Dir with new property Tool.Path

### DIFF
--- a/realize/projects.go
+++ b/realize/projects.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/fsnotify/fsnotify"
 	"log"
 	"math/big"
 	"os"
@@ -17,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/fsnotify/fsnotify"
 )
 
 var (
@@ -586,18 +587,18 @@ func (p *Project) run(path string, stream chan Response, stop <-chan bool) (err 
 		args = append(args, a...)
 	}
 	dirPath := os.Getenv("GOBIN")
-	if p.Tools.Run.Dir != "" {
-		dirPath, _ = filepath.Abs(p.Tools.Run.Dir)
+	if p.Tools.Run.Path != "" {
+		dirPath, _ = filepath.Abs(p.Tools.Run.Path)
 	}
 	name := filepath.Base(path)
-	if path == "." && p.Tools.Run.Dir == "" {
+	if path == "." && p.Tools.Run.Path == "" {
 		name = filepath.Base(Wdir())
-	} else if p.Tools.Run.Dir != "" {
+	} else if p.Tools.Run.Path != "" {
 		name = filepath.Base(dirPath)
 	}
 	path = filepath.Join(dirPath, name)
 	if p.Tools.Run.Method != "" {
-        path = p.Tools.Run.Method
+		path = p.Tools.Run.Method
 	}
 	if _, err := os.Stat(path); err == nil {
 		build = exec.Command(path, args...)
@@ -617,6 +618,9 @@ func (p *Project) run(path string, stream chan Response, stop <-chan bool) (err 
 	stderr, err := build.StderrPipe()
 	if err != nil {
 		return err
+	}
+	if p.Tools.Run.Dir != "" {
+		build.Dir = p.Tools.Run.Dir
 	}
 	if err := build.Start(); err != nil {
 		return err

--- a/realize/server.go
+++ b/realize/server.go
@@ -5,6 +5,7 @@ package realize
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
@@ -14,7 +15,6 @@ import (
 	"os/exec"
 	"runtime"
 	"strconv"
-	"errors"
 )
 
 // Dafault host and port

--- a/realize/tools.go
+++ b/realize/tools.go
@@ -14,6 +14,7 @@ import (
 type Tool struct {
 	Args   []string `yaml:"args,omitempty" json:"args,omitempty"`
 	Method string   `yaml:"method,omitempty" json:"method,omitempty"`
+	Path   string   `yaml:"path,omitempty" json:"dir,omitempty"`
 	Dir    string   `yaml:"dir,omitempty" json:"dir,omitempty"` //wdir of the command
 	Status bool     `yaml:"status,omitempty" json:"status,omitempty"`
 	Output bool     `yaml:"output,omitempty" json:"output,omitempty"`


### PR DESCRIPTION
I was misleading with tool option name `Dir` which commented as `WDir` (working directory?). So I've added new property `Path` which I think it's better than `Dir` in the way which `command` should be run in which specific `path`. Second, both `Path` and `Dir` match with `exec.Cmd.Path` and `exec.Cmd.Dir` as well.