### PR TITLE
Make use of cmd.Env to set custom environment variables

### DIFF
--- a/realize/projects.go
+++ b/realize/projects.go
@@ -116,12 +116,6 @@ func (p *Project) Before() {
 	}
 	// setup go tools
 	p.Tools.Setup()
-	// set env const
-	for key, item := range p.Env {
-		if err := os.Setenv(key, item); err != nil {
-			p.Buffer.StdErr = append(p.Buffer.StdErr, BufferOut{Time: time.Now(), Text: err.Error(), Type: "Env error", Stream: ""})
-		}
-	}
 	// global commands before
 	p.cmd(p.stop, "before", true)
 	// indexing files and dirs
@@ -621,6 +615,12 @@ func (p *Project) run(path string, stream chan Response, stop <-chan bool) (err 
 	}
 	if p.Tools.Run.Dir != "" {
 		build.Dir = p.Tools.Run.Dir
+	}
+	for _, e := range os.Environ() {
+        build.Env = append(build.Env, e)
+    }
+	for k, v := range p.Env {
+		build.Env = append(build.Env, fmt.Sprintf("%s=%s", k, v))
 	}
 	if err := build.Start(); err != nil {
 		return err

--- a/realize/tools.go
+++ b/realize/tools.go
@@ -14,7 +14,7 @@ import (
 type Tool struct {
 	Args   []string `yaml:"args,omitempty" json:"args,omitempty"`
 	Method string   `yaml:"method,omitempty" json:"method,omitempty"`
-	Path   string   `yaml:"path,omitempty" json:"dir,omitempty"`
+	Path   string   `yaml:"path,omitempty" json:"path,omitempty"`
 	Dir    string   `yaml:"dir,omitempty" json:"dir,omitempty"` //wdir of the command
 	Status bool     `yaml:"status,omitempty" json:"status,omitempty"`
 	Output bool     `yaml:"output,omitempty" json:"output,omitempty"`


### PR DESCRIPTION
This fix the problem when multiple project share same env name. Please check the code for more detail.