### PR TITLE
Fixed walking large directory issue

### DIFF
--- a/realize.go
+++ b/realize.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/oxequa/interact"
-	"github.com/oxequa/realize/realize"
+	"github.com/robcapo/realize/realize"
 	"gopkg.in/urfave/cli.v2"
 	"log"
 	"os"


### PR DESCRIPTION
Realize walks directories even if they are in the `Project.Watcher.Ignore` paths. This can cause very slow reinstall times (for me it was because my .git directory had a lot of objects.