### PR TITLE
Allow multiple projects to have different values for same env var

### DIFF
--- a/realize/projects_test.go
+++ b/realize/projects_test.go
@@ -44,18 +44,6 @@ func TestProject_Before(t *testing.T) {
 	if !strings.Contains(buf.String(), input) {
 		t.Error("Unexpected error")
 	}
-
-	r = Realize{}
-	r.Projects = append(r.Projects, Project{
-		parent: &r,
-		Env: map[string]string{
-			input: input,
-		},
-	})
-	r.Projects[0].Before()
-	if os.Getenv(input) != input {
-		t.Error("Unexpected error expected", input, "instead", os.Getenv(input))
-	}
 }
 
 func TestProject_Err(t *testing.T) {


### PR DESCRIPTION
Currently, you cannot have multiple projects using the same environment variable with a different value per project. Only the last `Before()` that is executed will be used on all projects in that are being run.

I have made an example Go project showing the problem: https://github.com/tapocol/realize-pr-example

With current realize, this will output:
```
[14:16:03][EXAMPLE1] : Watching 2 file/s 4 folder/s
[14:16:03][EXAMPLE2] : Watching 2 file/s 4 folder/s
[14:16:03][EXAMPLE1] : Install started
[14:16:03][EXAMPLE2] : Install started
[14:16:03][EXAMPLE2] : Install completed in 0.078 s
[14:16:03][EXAMPLE2] : Running..
[14:16:03][EXAMPLE2] : example2 env FOO=TWO
[14:16:03][EXAMPLE1] : Install completed in 0.079 s
[14:16:03][EXAMPLE1] : Running..
[14:16:03][EXAMPLE1] : example1 env FOO=TWO
```

I expect to see:
```
[14:18:23][EXAMPLE2] : Watching 2 file/s 4 folder/s
[14:18:23][EXAMPLE2] : Install started
[14:18:23][EXAMPLE1] : Watching 2 file/s 4 folder/s
[14:18:23][EXAMPLE1] : Install started
[14:18:23][EXAMPLE2] : Install completed in 0.079 s
[14:18:23][EXAMPLE2] : Running..
[14:18:23][EXAMPLE2] : example2 env FOO=TWO
[14:18:23][EXAMPLE1] : Install completed in 0.081 s
[14:18:23][EXAMPLE1] : Running..
[14:18:23][EXAMPLE1] : example1 env FOO=ONE
```

This PR gives the second result. I removed the `Before()` test for env, and I did not add another test as there are no tests setup for `run()`. Let me know your thoughts.