### PR TITLE
remove os.Exit after log.Fatal call

### DIFF
--- a/realize.go
+++ b/realize.go
@@ -108,7 +108,6 @@ func main() {
 	}
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)
-		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
This is effectively a dead code.