### PR TITLE
Temp fix to make tests run

### DIFF
--- a/realize/projects.go
+++ b/realize/projects.go
@@ -196,14 +196,15 @@ func (p *Project) Reload(path string, stop <-chan bool) {
 	}
 	// Go supported tools
 	if len(path) > 0 {
-		fi, err := os.Stat(path)
-		if filepath.Ext(path) == "" {
-			fi, err = os.Stat(path)
+		pathDir := filepath.Dir(path)
+		fi, err := os.Stat(pathDir)
+		if filepath.Ext(pathDir) == "" {
+			fi, err = os.Stat(pathDir)
 		}
 		if err != nil {
 			p.Err(err)
 		}
-		p.tools(stop, path, fi)
+		p.tools(stop, pathDir, fi)
 	}
 	// Prevent fake events on polling startup
 	p.init = true


### PR DESCRIPTION
This is a workaround to make issue #201 "work".

The problem seems to be that Test is marked as a "dir" tool, which means that the watcher will only trigger the Test tool if the watcher detects a change with a "dir".  But the watching logic always will only trigger on file changes (at least most of the time).

This hack makes it so in the watcher, when calling tools, it just goes ahead and gets the dir of the changed file.  That will cause the Test tool to be run.

This doesn't seem like an ideal fix, but it at least gets Test running again for people that like this tool