### PR TITLE
Fixed ignoring a file also ignoring the entire directory that contains it

### DIFF
--- a/realize/projects.go
+++ b/realize/projects.go
@@ -486,7 +486,13 @@ func (p *Project) cmd(stop <-chan bool, flag string, global bool) {
 // Watch the files tree of a project
 func (p *Project) walk(path string, info os.FileInfo, err error) error {
 	if p.shouldIgnore(path) {
-		return filepath.SkipDir
+		if info.IsDir() {
+			// If the path is a directory, skip all subdirectories as well
+			return filepath.SkipDir
+		} else {
+			// If the path is a single file, skip only that file
+			return nil
+		}
 	}
 
 	if p.Validate(path, true) {


### PR DESCRIPTION
Currently if a path to a file rather than a directory is specified to be ignored in the config, the rest of the files in its parent directory that come after it alphabetically will also be ignored.