### PR TITLE
Change import path of cli package

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -49,8 +49,8 @@
   name = "golang.org/x/net"
 
 [[constraint]]
-  branch = "v2"
-  name = "gopkg.in/urfave/cli.v2"
+  name = "github.com/urfave/cli/v2"
+  version = "2.0.0"
 
 [[constraint]]
   name = "gopkg.in/yaml.v2"

--- a/realize.go
+++ b/realize.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/oxequa/interact"
-	"github.com/yyh-gl/realize/realize"
+	"github.com/oxequa/realize/realize"
 	"github.com/urfave/cli/v2"
 )
 

--- a/realize.go
+++ b/realize.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/oxequa/interact"
-	"github.com/oxequa/realize/realize"
-	"gopkg.in/urfave/cli.v2"
+	"github.com/yyh-gl/realize/realize"
+	"github.com/urfave/cli/v2"
 )
 
 var r realize.Realize

--- a/realize/schema.go
+++ b/realize/schema.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"reflect"
 
-	"gopkg.in/urfave/cli.v2"
+	"github.com/urfave/cli/v2"
 )
 
 // Schema projects list

--- a/realize/schema_test.go
+++ b/realize/schema_test.go
@@ -2,9 +2,10 @@ package realize
 
 import (
 	"flag"
-	"gopkg.in/urfave/cli.v2"
 	"path/filepath"
 	"testing"
+
+	"github.com/urfave/cli/v2"
 )
 
 func TestSchema_Add(t *testing.T) {

--- a/realize/utils.go
+++ b/realize/utils.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"strings"
 
-	"gopkg.in/urfave/cli.v2"
+	"github.com/urfave/cli/v2"
 )
 
 // Params parse one by one the given argumentes

--- a/realize/utils_test.go
+++ b/realize/utils_test.go
@@ -2,10 +2,11 @@ package realize
 
 import (
 	"flag"
-	"gopkg.in/urfave/cli.v2"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/urfave/cli/v2"
 )
 
 func TestParams(t *testing.T) {

--- a/realize_test.go
+++ b/realize_test.go
@@ -3,10 +3,11 @@ package main
 import (
 	"bytes"
 	"errors"
-	"github.com/oxequa/realize/realize"
 	"log"
 	"strings"
 	"testing"
+
+	"github.com/yyh-gl/realize/realize"
 )
 
 var mockResponse interface{}

--- a/realize_test.go
+++ b/realize_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yyh-gl/realize/realize"
+	"github.com/oxequa/realize/realize"
 )
 
 var mockResponse interface{}


### PR DESCRIPTION
# Overview

Issue is [here](https://github.com/oxequa/realize/issues/262).

# Modifications

I changed import path of urfave/cli like below and fixed it.

Before: "gopkg.in/urfave/cli.v2"
After: "github.com/urfave/cli/v2"

# Test result

```
$ go test ./...
ok  	github.com/yyh-gl/realize	(cached)
ok  	github.com/yyh-gl/realize/realize	0.385s
```