### PR TITLE
fix: add os.environ when using env from yaml

### DIFF
--- a/realize/notify.go
+++ b/realize/notify.go
@@ -137,6 +137,13 @@ func (w *filePoller) Add(name string) error {
 		return errPollerClosed
 	}
 
+
+	if w.watches == nil {
+		w.watches = make(map[string]chan struct{})
+	} else if _, exists := w.watches[name]; exists {
+		return fmt.Errorf("watch exists")
+	}	
+	
 	f, err := os.Open(name)
 	if err != nil {
 		return err
@@ -146,12 +153,6 @@ func (w *filePoller) Add(name string) error {
 		return err
 	}
 
-	if w.watches == nil {
-		w.watches = make(map[string]chan struct{})
-	}
-	if _, exists := w.watches[name]; exists {
-		return fmt.Errorf("watch exists")
-	}
 	chClose := make(chan struct{})
 	w.watches[name] = chClose
 	go w.watch(f, fi, chClose)

--- a/realize/projects.go
+++ b/realize/projects.go
@@ -562,10 +562,25 @@ func (p *Project) stamp(t string, o BufferOut, msg string, stream string) {
 	}()
 }
 
+// buildEnvs returns a copy of strings representing the environment,
+// in the form "key=value".
 func (p Project) buildEnvs() (envs []string) {
-	for k, v := range p.Env {
-		envs = append(envs, fmt.Sprintf("%s=%s", strings.Replace(k, "=", "", -1), v))
+	envMap := make(map[string]string)
+
+	for _, env := range os.Environ() {
+		e := strings.SplitN(env, "=", 2)
+
+		envMap[e[0]] = e[1]
 	}
+
+	for k, v := range p.Env {
+		envMap[strings.Replace(k, "=", "", -1)] = v
+	}
+
+	for k, v := range envMap {
+		envs = append(envs, fmt.Sprintf("%s=%s", k, v))
+	}
+
 	return
 }
 


### PR DESCRIPTION
Pull request #203 introduced the ignoring of the OS environment which has already been noted by #258. This hopefully solves the problem by filling the env slice with the OS environment if no yaml env configuration for a key exist.